### PR TITLE
Support for multiple gateways and namespaces

### DIFF
--- a/lib/organiq.js
+++ b/lib/organiq.js
@@ -15,18 +15,37 @@ module.exports._LocalDeviceProxy = LocalDeviceProxy;
 /**
  * Create an Organiq node.
  *
+ * @param {Object=} options
+ * @param {Array<String>} options.domains list of domains for which this node
+ *  is authoritative.
+ * @param {String} options.defaultDomain the default domain to use when non-
+ *  qualified deviceids are used. If not specified, the default domain is '.'.
  * @returns {Organiq}
  * @constructor
  */
-function Organiq() {
+function Organiq(options) {
   if (!(this instanceof Organiq)) {
-    return new Organiq();
+    return new Organiq(options);
   }
+  options = options || {};
 
   this.stack = [];      // middleware stack, ordered toward downstream
   this.devices = {};    // registered device drivers by id
   this.proxies = {};    // arrays of connected local device proxies by id
-  this.gateway = null;  // upstream gateway for global namespace
+  this.domains = [];    // domains for which we are authoritative
+  this.gateways = {};   // upstream gateways by namespace
+
+  this.domains = options.domains || [];
+  this.defaultDomain = options.defaultDomain || '.';
+
+  // TODO: The eventual behavior here should be that we only set the local node
+  // TODO: as authority if the domain name matches one in this.domains. However,
+  // TODO: the existing logic expects us to act as authority for any domain that
+  // TODO: does not have a registered gateway. In particular, we have to find
+  // TODO: a way to deal with the fact that gateways might not be registered
+  // TODO: in advance of devices registering that rely on them...
+  this.localAuthorityIfNoGateway = true;
+
 
   /**
    * Return an ExpressJS-compatible middleware interface
@@ -51,19 +70,76 @@ function Organiq() {
 }
 util.inherits(Organiq, EventEmitter);
 
+/**
+ * @name AuthorityInfo
+ * @property {String} domain Normalized domain name
+ * @property {String} deviceid Normalized fully-qualified device name
+ * @property {Boolean} isLocal True if the local node is authoritative
+ * @property {Object|null} gateway
+ * @property {Boolean} isValid True if the device id is valid.
+ * @property {String} err if isValid is False, contains string describing error.
+ */
 
 /**
- * Determines whether the local node is authoritative for a given deviceid.
+ * Get information about the authority for a given deviceid.
  *
- * @param {String} deviceid
- * @returns {boolean} true if we are authoritative for the given device
+ * In addition to determining whether the local node is authoritative for a
+ * device or a connected gateway, this routine also supplies a normalized
+ * (canonical) deviceid by e.g., lower-casing the given name and appending the
+ * default domain if no domain was specified.
+ *
+ * @param {String} deviceid. Device ids are of the form '[<domain>:]<name>',
+ *  where [<domain>:] is optional. If no domain is specified (e.g., no colon
+ *  is present), the default domain will be used for the device. If an empty
+ *  domain is specified (e.g., the device id starts with a colon), then the
+ *  device is assumed to be in the local, non-routed namespace.
+ * @returns {AuthorityInfo} authority descriptor object
+ * @private
+ *
  */
-Organiq.prototype.isAuthoritative = function isAuthoritative(deviceid) {
-  // we currently only support a single namespace, and consider ourselves to
-  // be authoritative in any case where no gateway is configured.
-  void(deviceid);
-  return !this.gateway;
+Organiq.prototype.getDeviceAuthority = function getDeviceAuthority(deviceid) {
+  /** @type {AuthorityInfo|Object} */
+  var authority = {};
+
+  try {
+    var parts = deviceid.toLowerCase().split(':');
+    if (parts.length === 1) {
+      parts[1] = parts[0];
+      parts[0] = this.defaultDomain;
+    }
+    authority.deviceid = parts.join(':');
+    authority.domain = parts[0];
+
+    if (authority.domain === '') {
+      // An empty domain (e.g., one that was specified with a leading colon in
+      // the name) specifies the local, non-routed domain
+      authority.gateway = null;
+      authority.isLocal = true;
+    }
+    else if (this.localAuthorityIfNoGateway) {
+      // We are to act as the authority for this device if there is no gateway
+      // registered for the specified domain.
+      authority.gateway = this.gateways[authority.domain];
+      if (!authority.gateway) {
+        authority.gateway = this.gateways['*'];
+      }
+      authority.isLocal = !authority.gateway;
+    } else {
+      authority.isLocal = this.domains.indexOf(authority.domain) > -1;
+      authority.gateway = authority.isLocal ? null : this.gateways[authority.domain];
+      if (!authority.isLocal && !authority.gateway) {
+        authority.gateway = this.gateways['*'];
+      }
+    }
+    authority.isValid = !!(authority.isLocal || authority.gateway);
+  }
+  catch(e) {
+    authority.isValid = false;
+    authority.err = e.toString();
+  }
+  return authority;
 };
+
 
 
 /**
@@ -265,6 +341,7 @@ Organiq.prototype.dispatch = function dispatch(req) {
   }
 };
 
+
 /**
  * Register a device (or device proxy) with the system.
  *
@@ -282,9 +359,17 @@ Organiq.prototype.dispatch = function dispatch(req) {
  * @returns {DeviceWrapper} the device object given
  */
 Organiq.prototype.register = function(deviceid, device) {
+  var authority = this.getDeviceAuthority(deviceid);
+  if (!authority.isValid) {
+    return when.reject(new Error(authority.err));
+  }
+  deviceid = authority.deviceid;  // use the normalized device name
+
+  // Make sure we haven't already registered this deviceid.
   var devices = this.devices;
   if (typeof devices[deviceid] !== 'undefined') {
-    throw new Error('Register called for already registered deviceid: ' + deviceid);
+    return when.reject(new Error(
+      'Register called for already registered deviceid: ' + deviceid));
   }
 
   if (typeof device.on === 'function') {
@@ -311,16 +396,16 @@ Organiq.prototype.register = function(deviceid, device) {
   // (This is the normal case when we are running as a device container).
   // Note that we return synchronously to the local client, but the gateway
   // registration is asynchronous.
-  if (!this.isAuthoritative(deviceid)) {
+  if (authority.gateway) {
     var proxy = new LocalDeviceProxy(this, deviceid);
     if (!this.proxies[deviceid]) {
       this.proxies[deviceid] = [];
     }
     this.proxies[deviceid].push(proxy);
-    this.gateway.register(deviceid, proxy);
+    return authority.gateway.register(deviceid, proxy);
   }
 
-  return device;
+  return when.resolve(deviceid);
 };
 
 /**
@@ -333,10 +418,18 @@ Organiq.prototype.register = function(deviceid, device) {
  *
  */
 Organiq.prototype.deregister = function(deviceid) {
+  var authority = this.getDeviceAuthority(deviceid);
+  if (!authority.isValid) {
+    return when.reject(new Error(authority.err));
+  }
+  deviceid = authority.deviceid;  // use the normalized device name
+
   if (typeof this.devices[deviceid] === 'undefined') {
     debug('deregister called for unregistered deviceid: ' + deviceid);
-    return null;
+    return when.reject(new Error(
+      'deregister of unregistered device: ' + deviceid));
   }
+
   var device = this.devices[deviceid];
   device.removeAllListeners();
   delete this.devices[deviceid];
@@ -345,15 +438,15 @@ Organiq.prototype.deregister = function(deviceid) {
 
   // Remove the LocalDeviceProxy that was created during registration and
   // tell the gateway to deregister it.
-  if (!this.isAuthoritative(deviceid)) {
-    this.gateway.deregister(deviceid);
+  if (authority.gateway) {
     // there should be exactly one proxy in this case, as no proxy other than
     // the one used for the registration should be allowed (b/c we are not
     // authoritative for this device).
     // so, remove the entire entry
     delete this.proxies[deviceid];
+    return authority.gateway.deregister(deviceid);
   }
-  return device;
+  return when(device);
 };
 
 /**
@@ -385,12 +478,17 @@ Organiq.prototype.deregister = function(deviceid) {
  * @return {LocalDeviceProxy} device proxy (local or remote)
  */
 Organiq.prototype.connect = function(deviceid) {
+  var authority = this.getDeviceAuthority(deviceid);
+  if (!authority.isValid) {
+    return when.reject(new Error(authority.err));
+  }
+  deviceid = authority.deviceid;  // use the normalized device name
 
   // If we are authoritative for this device, create a proxy object that routes
   // requests through the local device stack. We save off a reference to the
   // proxy so that we can invoke it for device-originated messages from the
   // device.
-  if (this.isAuthoritative(deviceid)) {
+  if (authority.isLocal) {
     var proxy = new LocalDeviceProxy(this, deviceid);
     if (!this.proxies[deviceid]) {
       this.proxies[deviceid] = [];
@@ -407,7 +505,7 @@ Organiq.prototype.connect = function(deviceid) {
   // authoritative node even if the device is local (i.e., we are its device
   // container). This is necessary to ensure all requests for a device always
   // pass through the entire configured device stack.
-  return this.gateway.connect(deviceid);
+  return authority.gateway.connect(deviceid);
 };
 
 /**
@@ -416,18 +514,23 @@ Organiq.prototype.connect = function(deviceid) {
  * @params {LocalDeviceProxy} previously connected device proxy
  */
 Organiq.prototype.disconnect = function(proxy) {
+  var authority = this.getDeviceAuthority(proxy.deviceid);
+  if (!authority.isValid) {
+    return when.reject(new Error(authority.err));
+  }
+  var deviceid = authority.deviceid;  // use the normalized device name
 
-  if (this.isAuthoritative(proxy.deviceid)) {
-    var proxies = this.proxies[proxy.deviceid] || [];
+  if (authority.isLocal) {
+    var proxies = this.proxies[deviceid] || [];
     var idx = proxies.indexOf(proxy);
     if (idx > -1) {
       proxies.splice(idx, 1);
       if (proxies.length === 0) {
-        delete this.proxies[proxy.deviceid];
+        delete this.proxies[deviceid];
       }
     }
   } else {
-    return this.gateway.disconnect(proxy);
+    return authority.gateway.disconnect(proxy);
   }
 };
 
@@ -442,29 +545,44 @@ Organiq.prototype.disconnect = function(proxy) {
  * The device provided must implement register(), deregister(), connect(),
  * and disconnect().
  *
+ * @param {String} domain The domain for which this gateway is the authority.
+ *  May be a domain name or the wildcard '*' domain, in which case the gateway
+ *  is considered authority for all domains.
+ * @param {Object} gateway
+ *
  */
-Organiq.prototype.registerGateway = function(gateway) {
-  if (this.gateway) {
+Organiq.prototype.registerGateway = function(domain, gateway) {
+  domain = domain.toLowerCase();
+  if (this.gateways[domain]) {
     throw new Error('Gateway already registered.');
   }
-  this.gateway = gateway;
+  this.gateways[domain] = gateway;
 
-  // if any devices have already been registered, register them with the gateway.
-  var devices = this.devices;
-  for (var deviceid in devices) {
-    if (devices.hasOwnProperty(deviceid)) {
-      // TODO: This code is duplicated from register()
-      var proxy = new LocalDeviceProxy(this, deviceid);
-      if (!this.proxies[deviceid]) {
-        this.proxies[deviceid] = [];
+  if (this.localAuthorityIfNoGateway) {
+    // In this transitional case, we may have registered devices locally that
+    // should be registered with this gateway. Enumerate the registered devices,
+    // and for any that we determine the authority should be this new gateway,
+    // register them.
+    var devices = this.devices;
+    for (var deviceid in devices) {
+      if (devices.hasOwnProperty(deviceid)) {
+        var authority = this.getDeviceAuthority(deviceid);
+        if (authority.gateway === gateway) {
+          // TODO: This code is duplicated from register()
+          var proxy = new LocalDeviceProxy(this, deviceid);
+          if (!this.proxies[deviceid]) {
+            this.proxies[deviceid] = [];
+          }
+          this.proxies[deviceid].push(proxy);
+          gateway.register(deviceid, proxy);
+        }
       }
-      this.proxies[deviceid].push(proxy);
-      this.gateway.register(deviceid, proxy);
     }
+
   }
   debug('Gateway registered.');
 
-  this.emit('gatewayRegistered');
+  this.emit('gatewayRegistered', domain);
   return gateway;
 };
 
@@ -472,13 +590,14 @@ Organiq.prototype.registerGateway = function(gateway) {
  * Remove a gateway.
  *
  */
-Organiq.prototype.deregisterGateway = function() {
-  if (!this.gateway) {
+Organiq.prototype.deregisterGateway = function(domain) {
+  domain = domain.toLowerCase();
+  if (!this.gateways[domain]) {
     throw new Error('There is no registered gateway.');
   }
-  debug('Gateway deregistered.');
+  delete this.gateways[domain];
 
-  this.gateway = null;
+  debug('Gateway deregistered.');
   return true;
 };
 

--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -153,8 +153,8 @@ void(WebSocketRequest);
  *
  * @param {Organiq} organiq The core device proxy object
  * @param {object} options
- * @param {Boolean} options.gateway If set, this connection will register as
- *  a gateway.
+ * @param {String} options.domain If set, this connection will register as
+ *  a gateway authoritative for the given domain.
  * @returns {Function} handler function to be installed for 'connection'
  *  or 'open' handler.
  *
@@ -162,6 +162,7 @@ void(WebSocketRequest);
 function WebSocketApi(organiq, options) {
   options = options || {};
   options.gateway = options.gateway ? true : false;
+  options.domain = options.domain || '*';
 
   /**
    * Connection handler function.
@@ -271,7 +272,7 @@ function WebSocketApi(organiq, options) {
     // registrations need to be forwarded to the remote node. We do this by
     // exposing methods to the local host through a registered gateway object.
     if (options.gateway) {
-      organiq.registerGateway(new WebSocketGateway(connection));
+      organiq.registerGateway(options.domain, new WebSocketGateway(connection));
     }
 
     /**
@@ -531,7 +532,7 @@ function WebSocketApi(organiq, options) {
       }
       proxies = {};
       if (options.gateway) {
-        organiq.deregisterGateway();
+        organiq.deregisterGateway(options.domain);
       }
     }
 
@@ -847,6 +848,14 @@ WebSocketGateway.prototype.disconnect = function(proxy) {
     });
 };
 
+/**
+ * Register a device with the remote host.
+ *
+ * @param deviceid
+ * @param device
+ * @return {Promise<String|Error>} A promise resolving to the deviceid used in
+ *  the registration, or an Error on rejection.
+ */
 WebSocketGateway.prototype.register = function(deviceid, device) {
   // We are given a LocalDeviceProxy, which sits upstream of the device stack.
   // We will be able to invoke the get, set, etc methods when we receive
@@ -859,17 +868,21 @@ WebSocketGateway.prototype.register = function(deviceid, device) {
     deviceid: deviceid,
     connid: connid
   };
-  return this.connection.sendRequest(req)
-    .then(function(res) {
-      return res;
-    });
+  return this.connection.sendRequest(req);
 };
 
+/**
+ * Deregister a previously-registered device with the remote host.
+ *
+ * @param deviceid
+ * @return {Promise<String|Error>} A promise resolving to the deviceid of the
+ *  device deregistered, or rejecting as an Error.
+ */
 WebSocketGateway.prototype.deregister = function(deviceid) {
 
   var connid = this.connection.disconnectLocalDeviceByDeviceId(deviceid);
   if (!connid) {
-    return when_.reject('device was not registered.');
+    return when_.reject(new Error('device was not registered.'));
   }
 
   var req = {
@@ -877,19 +890,16 @@ WebSocketGateway.prototype.deregister = function(deviceid) {
     deviceid: deviceid,
     connid: connid
   };
-  return this.connection.sendRequest(req)
-    .then(function(res) {
-      return res;
-    });
+  return this.connection.sendRequest(req);
 };
 
 /**
- * Send a NOTIFY message to an authoritative gateway.
+ * Send a NOTIFY message to the remote host.
  *
  * @param deviceid
  * @param event
  * @param params
- * @returns {Promise|*}
+ * @returns {Promise<Boolean|Error>}
  */
 WebSocketGateway.prototype.notify = function(deviceid, event, params) {
   var req = {
@@ -898,12 +908,17 @@ WebSocketGateway.prototype.notify = function(deviceid, event, params) {
     identifier: event,
     params: params
   };
-  return this.connection.sendRequest(req)
-    .then(function(res) {
-      return res;
-    });
+  return this.connection.sendRequest(req);
 };
 
+/**
+ * Send a PUT message to the remote host.
+ *
+ * @param deviceid
+ * @param metric
+ * @param value
+ * @return {Promise<Boolean|Error>}
+ */
 WebSocketGateway.prototype.put = function(deviceid, metric, value) {
   var req = {
     method: 'PUT',
@@ -911,9 +926,6 @@ WebSocketGateway.prototype.put = function(deviceid, metric, value) {
     identifier: metric,
     value: value
   };
-  return this.connection.sendRequest(req)
-    .then(function(res) {
-      return res;
-    });
+  return this.connection.sendRequest(req);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "organiq-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Organiq Core Platform.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "chai": "^2.1.1",
+    "chai-as-promised": "^4.3.0",
     "coffee-script": "^1.9.1",
     "jshint": "^2.6.3",
     "mocha": "^2.1.0",

--- a/test/common.coffee
+++ b/test/common.coffee
@@ -1,8 +1,10 @@
 global.chai = require 'chai'
 global.sinon = require 'sinon'
 global.sinonChai = require 'sinon-chai'
+global.chaiAsPromised = require 'chai-as-promised'
 global.chai.should()
 global.chai.use(sinonChai)
+global.chai.use(chaiAsPromised)
 
 global.when_ = require 'when'
 

--- a/test/e2e/basic.test.coffee
+++ b/test/e2e/basic.test.coffee
@@ -22,7 +22,7 @@ describe 'WebSocket device API', ->
     ws = wss = app = null
 
   describe 'Device registration', ->
-    testDeviceId = 'test-register-deviceid'
+    testDeviceId = '.:test-register-deviceid'
     testReqId = 'test-register-reqid'
 
     # Helper function to register a test device with the server

--- a/test/unit/api.test.coffee
+++ b/test/unit/api.test.coffee
@@ -2,7 +2,7 @@ Organiq = require '../../'
 EventEmitter = require('events').EventEmitter
 
 describe 'Organiq', ->
-  testDeviceId = 'test-device-id'
+  testDeviceId = 'example.com:test-device-id'
   # @type {Organiq}
   o = null
   beforeEach ->
@@ -17,20 +17,69 @@ describe 'Organiq', ->
       req = Organiq()
       req.should.be.an.instanceof Organiq
 
-  describe 'isAuthoritative', ->
-    it 'should return true if no gateway has been registered', ->
-      o.isAuthoritative(testDeviceId).should.be.true
+  describe 'getDeviceAuthority', ->
+    it 'isLocal should be true if no gateway has been registered', ->
+      authority = o.getDeviceAuthority testDeviceId
+      authority.should.exist
+      authority.isLocal.should.be.true
 
-    it 'should return false if gateway has been registered', ->
+    it 'isLocal should be false if gateway has been registered', ->
       g = {}
-      o.registerGateway(g)
-      o.isAuthoritative(testDeviceId).should.be._false
+      o.registerGateway('example.com', g)
+      authority = o.getDeviceAuthority testDeviceId
+      authority.isLocal.should.be.false
 
-    it 'should return true if gateway has been registered and unregistered', ->
+    it 'isLocal should be true if gateway registered and unregistered', ->
       g = {}
-      o.registerGateway(g)
-      o.deregisterGateway()
-      o.isAuthoritative(testDeviceId).should.be.true
+      o.registerGateway('example.com', g)
+      o.deregisterGateway('example.com')
+      authority = o.getDeviceAuthority testDeviceId
+      authority.isLocal.should.be.true
+
+    it 'domain should parse correctly', ->
+      authority = o.getDeviceAuthority testDeviceId
+      authority.domain.should.equal 'example.com'
+
+    it 'should lowercase domain', ->
+      authority = o.getDeviceAuthority 'EXAMPLE.COM:test-device-id'
+      authority.domain.should.equal 'example.com'
+
+    it 'should lowercase deviceid', ->
+      d = 'example.com:TEST-DEVICE-ID'
+      authority = o.getDeviceAuthority d
+      authority.deviceid.should.equal d.toLowerCase()
+
+    it 'should match wildcard domain', ->
+      g = { test: 'marker' }
+      o.registerGateway('*', g)
+      authority = o.getDeviceAuthority testDeviceId
+      authority.gateway.should.deep.equal g
+
+    it 'should match specific domain before wildcard', ->
+      g1 = { test: 'marker1' }
+      g2 = { test: 'marker2' }
+      o.registerGateway('*', g1)
+      o.registerGateway('example.com', g2)
+
+      authority = o.getDeviceAuthority testDeviceId
+      authority.gateway.should.deep.equal g2
+
+    it 'should use defaultDomain if no domain specified', ->
+      o = new Organiq({ defaultDomain: 'test.default.domain' })
+      authority = o.getDeviceAuthority 'not-fully-qualified-device-id'
+      authority.domain.should.equal 'test.default.domain'
+
+    it 'should register locally if empty domain specified', ->
+      o = new Organiq({ defaultDomain: 'test.default.domain' })
+      authority = o.getDeviceAuthority ':local-device-id'
+      authority.domain.should.equal ''
+
+    it 'should register locally if empty domain when wildcard gateway present', ->
+      o = new Organiq({ defaultDomain: 'test.default.domain' })
+      g1 = { test: 'marker1' }
+      o.registerGateway('*', g1)
+      authority = o.getDeviceAuthority ':local-device-id'
+      authority.domain.should.equal ''
 
   describe 'register', ->
     it 'registers `notify` and `put` handlers on EventEmitter devices', ->
@@ -47,7 +96,41 @@ describe 'Organiq', ->
       spy.should.have.been.calledWith 'notify'
       spy.should.have.been.calledWith 'put'
 
+    it 'ignores registered gateway for default', ->
+      g1 = { register: (deviceid, device) -> when_(true) }
+      g2 = { register: (deviceid, device) -> when_(true) }
+      d = { on: (ev, fn) -> }
+      spy1 = sinon.spy g1, 'register'
+      spy2 = sinon.spy g2, 'register'
+
+      o.registerGateway('domain1', g1);
+      o.registerGateway('domain2', g2);
+
+      devicePromise = o.register 'device-no-domain', d
+      spy1.should.not.have.been.called
+      spy2.should.not.have.been.called
+
+      # domain name will be normalized with default domain
+      devicePromise.should.eventually.equal '.:device-no-domain'
+
+    it 'chooses proper gateway for named domain', ->
+      g1 = { register: (deviceid, device) -> when_(deviceid) }
+      g2 = { register: (deviceid, device) -> when_(deviceid) }
+      d = { on: (ev, fn) -> }
+      spy1 = sinon.spy g1, 'register'
+      spy2 = sinon.spy g2, 'register'
+
+      o.registerGateway('domain1', g1);
+      o.registerGateway('domain2', g2);
+
+      devicePromise = o.register 'domain1:test-device', d
+      spy1.should.have.been.calledWith 'domain1:test-device'
+      spy2.should.not.have.been.called
+
+      devicePromise.should.eventually.equal 'domain1:test-device'
+
+
   describe 'deregister', ->
-    it 'should return null for unregistered device', ->
-      (o.deregister(testDeviceId) == null).should.be.true
+    it 'should reject for unregistered device', ->
+      o.deregister(testDeviceId).should.be.rejectedWith Error
 

--- a/test/unit/deviceProxy.test.coffee
+++ b/test/unit/deviceProxy.test.coffee
@@ -8,7 +8,7 @@ when_ = require 'when'
 # interface interacts with organiq.dispatch() as expected.
 #
 describe 'LocalDeviceProxy', ->
-  testDeviceId = 'test-device-id'
+  testDeviceId = '.:test-device-id'
   app = null
   proxy = null
   spy = null
@@ -60,7 +60,7 @@ describe 'LocalDeviceProxy', ->
     app.__dispatch req
 
 describe 'Organiq connect and disconnect', ->
-  testDeviceId = 'test-device-id'
+  testDeviceId = '.:test-device-id'
   app = null
   spy = null
   beforeEach ->

--- a/test/unit/transports/websocket.test.coffee
+++ b/test/unit/transports/websocket.test.coffee
@@ -73,7 +73,9 @@ describe 'WebSocketAPI module', ->
       handler = WebSocketApi(mock_app, { gateway: true })
       handler(mock_ws)
       spy_registerGateway.should.have.been.calledOnce
-      gateway = spy_registerGateway.getCall(0).args[0]
+      domain = spy_registerGateway.getCall(0).args[0]
+      gateway = spy_registerGateway.getCall(0).args[1]
+      domain.should.equal '*'
       gateway.should.be.instanceOf(WebSocketApi._WebSocketGateway)
 
     it 'should not register gateway if gateway:true option unspecified', ->


### PR DESCRIPTION
This update adds support for multiple namespaces (domains) and multiple gateway connections on each node. 

deviceids in the core interfaces are now of the form "[domain:]id", where the "domain:" part is optional. 
