### PR TITLE
Add CoreDevice (`:core`) to expose registered devices

### DIFF
--- a/lib/coreDevice.js
+++ b/lib/coreDevice.js
@@ -1,0 +1,72 @@
+/**
+ * Module dependencies.
+ */
+
+
+/**
+ * Organiq Core Device
+ */
+var device = module.exports = OrganiqCoreDevice;
+
+/*
+ * Core Device Object
+ *
+ * One instance of OrganiqCoreDevice is created on each core node, providing
+ * an interface to administrative functionality for the node.
+ *
+ * The device is registered in the non-routed (empty) domain as ':core'.
+ *
+ * @param {Organiq} organiq The organiq node
+ * @returns {OrganiqCoreDevice}
+ * @constructor
+ * @private
+ */
+function OrganiqCoreDevice(organiq) {
+  if (!(this instanceof OrganiqCoreDevice)) {
+    return new OrganiqCoreDevice(organiq);
+  }
+  this.organiq = organiq;
+}
+
+device.prototype.get = function(property) {
+  switch (property) {
+    case 'ConnectedDevices':
+      return this.organiq.getAttachedDeviceInfo();
+    default:
+      throw Error('Unknown property \'' + property + '\'');
+  }
+};
+
+device.prototype.set = function(property, value) {
+  void(property);
+  void(value);
+  throw Error('Not supported');
+};
+
+device.prototype.invoke = function(method, params) {
+  void(method);
+  void(params);
+  throw Error('Not supported');
+};
+
+device.prototype.subscribe = function(event) {
+  void(event);
+  throw Error('Not supported');
+};
+
+device.prototype.describe = function(property) {
+  void(property);
+  return {
+    methods: {},
+    events: {},
+    properties: {
+      'ConnectedDevices': { type: 'object' }
+    }
+  };
+};
+
+device.prototype.config = function(property, value) {
+  void(property);
+  void(value);
+  throw Error('Not supported');
+};

--- a/lib/organiq.js
+++ b/lib/organiq.js
@@ -5,7 +5,7 @@ var when = require('when');
 var debug = require('debug')('organiq:core');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
-
+var CoreDevice = require('./coreDevice.js');
 module.exports = Organiq;
 
 /* test-code */
@@ -67,6 +67,8 @@ function Organiq(options) {
     return websocket(this, options);
   };
 
+  // register the Core device in the local (non-routed) domain.
+  this.register(':core', new CoreDevice(this));
 }
 util.inherits(Organiq, EventEmitter);
 
@@ -599,6 +601,37 @@ Organiq.prototype.deregisterGateway = function(domain) {
 
   debug('Gateway deregistered.');
   return true;
+};
+
+
+/**
+ * @name AttachedDevice
+ * @property {String} deviceid Normalized fully-qualified device name
+ * @property {String} domain Normalized domain name
+ * @property {Boolean} isLocal True if the local node is authoritative
+ */
+
+/**
+ * Get Information about devices attached to this node.
+ *
+ * @return {Array<AttachedDevice>} list of attached devices.
+ * @private
+ */
+Organiq.prototype.getAttachedDeviceInfo = function() {
+  var registeredDevices = [];
+
+  var self = this;
+  Object.keys(this.devices).forEach(function(deviceid) {
+    var authority = self.getDeviceAuthority(deviceid);
+    var deviceInfo = {
+      deviceid: authority.deviceid,
+      domain: authority.domain,
+      isLocal: authority.isLocal
+    };
+    registeredDevices.push(deviceInfo);
+  });
+
+  return registeredDevices;
 };
 
 /**

--- a/test/e2e/basic.test.coffee
+++ b/test/e2e/basic.test.coffee
@@ -112,12 +112,12 @@ describe 'WebSocket device API', ->
 
       ws.send JSON.stringify(message)
 
-    it 'should deregister all devices on disconnect', (done) ->
+    it 'should deregister device on disconnect', (done) ->
       registerDevice ->
         ws.on 'close', ->
           # need to delay a bit to let the server rundown the connection
           callback = ->
-            app.devices.should.be.empty
+            app.devices.should.not.have.property testDeviceId
             done()
           setTimeout callback, 100
 

--- a/test/unit/coreDevice.test.coffee
+++ b/test/unit/coreDevice.test.coffee
@@ -1,0 +1,38 @@
+Organiq = require '../../'
+OrganiqCoreDevice = require '../../lib/coreDevice.js'
+EventEmitter = require('events').EventEmitter
+
+describe 'CoreDevice', ->
+  # @type {OrganiqCoreDevice}
+  cd = null
+  o = null
+  beforeEach ->
+    stub_getAttachedDeviceInfo = sinon.stub().returns { stuff: 'here' }
+    o =
+      getAttachedDeviceInfo: stub_getAttachedDeviceInfo
+    cd = new OrganiqCoreDevice(o)
+
+  describe 'constructor', ->
+    it 'should return an instance of OrganiqCoreDevice', ->
+      cd = new OrganiqCoreDevice(o)
+      cd.should.be.an.instanceof OrganiqCoreDevice
+
+    it 'should return an instance of Organiq when invoked without `new`', ->
+      cd = OrganiqCoreDevice()
+      cd.should.be.an.instanceof OrganiqCoreDevice
+
+  describe 'schema', ->
+    schema = null
+    beforeEach ->
+      schema = cd.describe()
+
+    it 'should return valid schema object', ->
+      schema.should.exist
+      schema.should.have.property 'methods'
+      schema.should.have.property 'events'
+      schema.should.have.property 'properties'
+
+    it 'should support ConnectedDevices property', ->
+      properties = schema.properties
+      properties.should.have.property 'ConnectedDevices'
+


### PR DESCRIPTION
This change creates a virtual device named `:core` on every node, which currently supports a single method to enumerate currently-registered devices. It is registered in the null (non-routed) namespace, so is not available from external nodes.
